### PR TITLE
Add CMAKE_FLAGS, set from env var for global flags.

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -63,7 +63,8 @@ if [[ -z "${external_init}" ]]; then
     # if .buildopts exists, use it
     [ -f .buildopts ] && . .buildopts
 
-    cmake .
+    echo == xcmessages CMAKE_FLAGS: ${CMAKE_FLAGS}
+    cmake ${CMAKE_FLAGS} .
 
     # parallel build make - find ncpu
     ncpu=1 #default


### PR DESCRIPTION
* Allows CMAKE_FLAGS=-DCMAKE_BUILD_TYPE=Debug
* "echo ==  ..." provides a concrete trail of how CMake was run, in the face of suspect results. 