### PR TITLE
Add 'libncurses-dev' as a workaround to satisfy builds.

### DIFF
--- a/deps/install-deps-apt.sh
+++ b/deps/install-deps-apt.sh
@@ -30,6 +30,9 @@ echo "Installing compiler and build tools..."
 sudo apt install clang-12 libstdc++-10-dev
 sudo apt install cmake automake autoconf autogen libtool checkinstall wget curl unzip
 
+echo "Install application dev dependencies..."
+sudo apt install libncurses-dev # not used directly by "messages".
+
 echo "Your current C compiler is:"
 which cc
 cc --version


### PR DESCRIPTION
This actually belongs in "common", which uses <curses.h>,
but there is no package install script in there.
So for now, it's here.