### PR TITLE
Rewrite build.sh to unify compile commands, but add visibility.

### DIFF
--- a/examples/hello_vector/cpp/build.sh
+++ b/examples/hello_vector/cpp/build.sh
@@ -1,34 +1,66 @@
 #!/bin/bash
 
+while [ $# -gt 0 ]; do
+    # echo arg $1
+    case "$1" in
+        TC=*)   # alternative to TOOLCHAIN env var
+            TOOLCHAIN=${1/TC=/}
+            ;;
+        -q)     # quick/quiet mode, no prompts/no pause
+            qq=qqq
+            ;;
+    esac
+    shift
+done
 
-if [[ ! -z "${GOOGLE_ROOT}" ]]; then
+# GOOGLE_ROOT points to the root of where the following are found:
+#   include/google/protobuf
+#   lib/libprotobuf*
+if [ "${GOOGLE_ROOT}" ]; then
+    LPROTOFLAGS="-L${GOOGLE_ROOT}/lib"
+fi
 
-    ln -fs ../../../bindings/cpp/vector.pb.h
+case "$TOOLCHAIN" in
+    Clang|CLANG)
+        CXX=clang++
+        # CXXFLAGS="stdlib=libc++ -lc++abi -lsupc++ -lc++fs"     # for some systems
+        ;;
+    Gcc|GCC) CXX=g++
+        ;;
+    *) CXX=c++
+        ;;
+esac
 
-    if [[ "$TOOLCHAIN" == "Clang" ]]; then
-        clang++ -stdlib=libc++ -lc++abi -lsupc++ -lc++fs save_vector.cpp -o save_vector -L../../../lib/static -lxcmessages -L${GOOGLE_ROOT}/lib -lprotobuf
-        clang++ -stdlib=libc++ -lc++abi -lsupc++ -lc++fs load_vector.cpp -o load_vector -L../../../lib/static -lxcmessages -L${GOOGLE_ROOT}/lib -lprotobuf
-    else
-        g++ save_vector.cpp -o save_vector -L../../../lib/static -lxcmessages -L${GOOGLE_ROOT}/lib -lprotobuf
-        g++ load_vector.cpp -o load_vector -L../../../lib/static -lxcmessages -L${GOOGLE_ROOT}/lib -lprotobuf
-    fi
-
-else
-
+if [ ! "${qq}" ];  then
     echo "compiling messages example app: 'hello_vector' ..."
     read -p "Press [enter] to continue."
 
-    # make links to required library and (for convenience)
-    ln -f ../../../lib/static/libxcmessages.a libxcmessages.a
-    ln -f ../../../bindings/cpp/vector.pb.h vector.pb.h
-
-    # Note:  your LD_LIBRARY_PATH has to be appropriately set to find libprotobuf.{so,a}
-    # invoke c++ compiler on save source to create app:
-    c++ save_vector.cpp -o save_vector libxcmessages.a -lprotobuf
-
-    # Note:  your LD_LIBRARY_PATH has to be appropriately set to find libprotobuf.{so,a}
-    # invoke c++ compiler on load source to create app:
-    c++ load_vector.cpp -o load_vector libxcmessages.a -lprotobuf
-
-    read -p "Press [enter] to close."
+    ${CXX} --version    # print compiler version
 fi
+
+ln -f ../../../bindings/cpp/vector.pb.h
+ln -f ../../../lib/static/libxcmessages.a
+
+set -x
+# invoke CXX compiler on save_vector source to create app:
+${CXX} ${CXXFLAGS} save_vector.cpp -o save_vector -L. -lxcmessages ${LPROTOFLAGS} -lprotobuf
+# invoke CXX compiler on load_vector source to create app:
+${CXX} ${CXXFLAGS} load_vector.cpp -o load_vector -L. -lxcmessages ${LPROTOFLAGS} -lprotobuf
+set +x
+
+if [ "${qq}" ]; then
+    exit 0
+fi
+
+ls -l save_vector load_vector
+
+cat <<-Build_Epilog
+The apps will use the shared-object version of libprotobuf.
+Your LD_LIBRARY_PATH has to be appropriately set to find libprotobuf.so.
+If in doubt of where the apps are finding it, run these commands:
+    ldd save_vector
+    ldd load_vector
+
+Build_Epilog
+
+read -p "Press [enter] to close."


### PR DESCRIPTION
Attempting to retain power of the original script, but provide easier path for novices.
* 3 sets of compile commands collapsed into 1 set, but with parameterization of CXX, CXXFLAGS, and LPROTOFLAGS. Use "set +x" to show the resulting compile commands.
* Provide commented out Clang "stdlib=libc++ ..."; builds successfully without this on Ubuntu 20.04/Clang-10. (With it caused build problems.) Retain as comment for other DistroRel/Clang permutations.
* Add text epilog to warn users to set LD_LIBRARY_PATH.
* Add "CXX --version" so that CXX=c++ reports what compiler is used; could be either g++ or clang++, depending on /etc/alternatives/c++.